### PR TITLE
Set transaction isolation level to repeatable read

### DIFF
--- a/planet06_pg.cpp
+++ b/planet06_pg.cpp
@@ -459,7 +459,7 @@ int main(int argc, char **argv)
     // open database connection
     pqxx::connection conn(connection_params);
     pqxx::work xaction(conn);
-    xaction.exec("set transaction isolation level serializable read only");
+    xaction.exec("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY");
 
     fetch_users(xaction);
 


### PR DESCRIPTION
Switch to transaction isolation level to repeatable read to allow running against slave db.
